### PR TITLE
Added support to install github CLI by default to the codespace

### DIFF
--- a/setup-ai-assistant.sh
+++ b/setup-ai-assistant.sh
@@ -18,6 +18,18 @@ if ! command -v claude &> /dev/null; then
     exit 0
 fi
 
+# --- Install GitHub CLI ---
+if ! command -v gh &> /dev/null; then
+    echo "Installing GitHub CLI..."
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+    sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+    sudo apt update
+    sudo apt install gh -y
+else
+    echo "GitHub CLI already installed"
+fi
+
 # --- Create directories ---
 mkdir -p .claude/skills
 


### PR DESCRIPTION
The default install script now installs GH CLI on the codespace. The current assumption is that the Codespace is running a Linux or Unix OS.